### PR TITLE
updated the node to deploy gpt-researcher

### DIFF
--- a/infra/research-gpt/values-prod.yaml
+++ b/infra/research-gpt/values-prod.yaml
@@ -96,8 +96,8 @@ volumeMounts:
   mountPath: "/outputs"
   readOnly: false
 
-# nodeSelector:
-#   node-group: gpt-researcher
+nodeSelector:
+  node: gpt
 
 tolerations: []
 


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request modifies the node selector configuration for the `gpt-researcher` node group, removing the specific label selection and setting it to `node: gpt` instead.

**Key Points**

* Removes `nodeSelector` configuration for `gpt-researcher` node group.
* Sets node selector to `node: gpt`. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>