### PR TITLE
deploying gpt to old node - t3.xlarge

### DIFF
--- a/infra/research-gpt/values-prod.yaml
+++ b/infra/research-gpt/values-prod.yaml
@@ -96,8 +96,8 @@ volumeMounts:
   mountPath: "/outputs"
   readOnly: false
 
-nodeSelector:
-  node: gpt
+# nodeSelector:
+#   node: gpt
 
 tolerations: []
 


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary:**
Removed `nodeSelector` configuration for a Kubernetes deployment from `values-prod.yaml`.

**Key Points:**
- Deleted `nodeSelector: node: gpt` from `values-prod.yaml`.
- No other changes were made to the file. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>