### PR TITLE
ENGG-2477 send task id

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -117,6 +117,7 @@ async def websocket_endpoint(websocket: WebSocket, psql_sess: Annotated[AsyncSes
                 specialization, prompts_from_db = await read_prompt_template_by_prompts_id(psql_sess=psql_sess, cols=["name", "template"], prompts_id=agent_conf.prompts_id)
                 task_id = await save_report(psql_sess=psql_sess, report={"user_id": user_id, "base_id": base_id, "agent_id": agent_id, "title": task, "content": '', "report_style": report_style, "report_source": report_source, "published": False}, returning=['id'])
                 task_id, = task_id[0]
+                await websocket.send_json({"type": "task_id", "output": task_id})
                 if task and report_type:
                     report = await manager.start_streaming(
                         task, task_id, report_type, report_style, report_source, source_urls, tone, websocket, headers, specialization,


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request adds real-time feedback in web socket communication by sending the task ID to the client upon task creation.

**Key Points**

1. A new line is added to send the task ID as a JSON message to the client.
2. The `websocket_endpoint` function is enhanced to include this new feature. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>